### PR TITLE
add logo-img and houese-img

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,9 +6,12 @@
     <title>Sorting Hat Quiz</title>
     <link rel="stylesheet" href="styles.css" />
     <link rel="icon" href="./icons/icon.png" />
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Almendra+Display&family=Cinzel+Decorative:wght@400;700;900&family=Gloock&family=Libre+Baskerville:ital,wght@0,400;0,700;1,400&family=MedievalSharp&display=swap" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Almendra+Display&family=Cinzel+Decorative:wght@400;700;900&family=Gloock&family=Libre+Baskerville:ital,wght@0,400;0,700;1,400&family=MedievalSharp&display=swap"
+      rel="stylesheet"
+    />
   </head>
   <body>
     <div class="light-sweep"></div>
@@ -22,6 +25,11 @@
     </div>
 
     <div class="spell-container">
+      <img
+        class="logo-img"
+        src="https://wallpapercave.com/wp/wp2275854.png"
+        alt="logo"
+      />
       <div class="spell-internal-container">
         <div>
           <h1>Spell of the day</h1>
@@ -31,6 +39,11 @@
           <span id="spellText" class="spell-text"></span>
         </div>
       </div>
+      <img
+        class="houses-img"
+        src="https://wallpapercave.com/wp/wp12750430.jpg"
+        alt="houses"
+      />
     </div>
     <div class="container">
       <p class="questP">Answer the questions below to find out your house!</p>

--- a/styles.css
+++ b/styles.css
@@ -29,13 +29,16 @@ h1 {
   border-radius: 8px;
   transition: background-color 0.3s;
 }
+
 @keyframes lightSweep {
   0% {
     background-position: 0% 50%;
   }
+
   50% {
     background-position: 100% 50%;
   }
+
   100% {
     background-position: 0% 50%;
   }
@@ -47,12 +50,10 @@ h1 {
   left: 0;
   width: 100%;
   height: 100%;
-  background: linear-gradient(
-    120deg,
-    rgba(255, 255, 255, 0.05),
-    rgba(255, 255, 255, 0.2),
-    rgba(255, 255, 255, 0.05)
-  );
+  background: linear-gradient(120deg,
+      rgba(255, 255, 255, 0.05),
+      rgba(255, 255, 255, 0.2),
+      rgba(255, 255, 255, 0.05));
   background-size: 200%;
   animation: lightSweep 4s infinite;
   z-index: 1;
@@ -64,58 +65,68 @@ h1 {
 }
 
 .video-container {
-    position: absolute;
-    top: 0;
-    left: 0;
-    border-radius: 15px;
-    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
-    width: 100%; /* Adjust the width as needed */
-    height: 266px; /* Adjust the height to fit the space you want */
-    overflow: hidden; /* Ensures the video doesn't exceed the container */
-    z-index: 2; /* Behind the form */
+  position: absolute;
+  top: 0;
+  left: 0;
+  border-radius: 15px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
+  width: 100%;
+  /* Adjust the width as needed */
+  height: 266px;
+  /* Adjust the height to fit the space you want */
+  overflow: hidden;
+  /* Ensures the video doesn't exceed the container */
+  z-index: 2;
+  /* Behind the form */
 }
 
 video {
-    width: 100%; 
-    opacity: 50%;
-    height: auto; /* Cover the container's height */
-    object-fit: cover; /* Ensures the video covers the entire container */
+  width: 100%;
+  opacity: 50%;
+  height: auto;
+  /* Cover the container's height */
+  object-fit: cover;
+  /* Ensures the video covers the entire container */
 }
 
-.questP{
-    font-family: 'almendra-display-regular',serif;
-    font-size: 1.5rem;
-    margin: 1% 2%;
-    color: red;
-    text-shadow: 0px 0px 2px black;
+.questP {
+  font-family: 'almendra-display-regular', serif;
+  font-size: 1.5rem;
+  margin: 1% 2%;
+  color: red;
+  text-shadow: 0px 0px 2px black;
 }
 
-h3{
-    font-family: 'medievalsharp-regular',serif;
-    font-size: 1.2rem;
+h3 {
+  font-family: 'medievalsharp-regular', serif;
+  font-size: 1.2rem;
 }
 
-.question{
-    font-family: 'libre-baskerville-bold',serif;
-    font-weight:  600;
+.question {
+  font-family: 'libre-baskerville-bold', serif;
+  font-weight: 600;
 
 }
 
 .overlay-text {
-    position: absolute;
-    top: 40%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    z-index: 2;
-    font-family: 'Cinzel Decorative',serif;
-    color: #fffae6;;
-    font-size: 53px; /* Adjust size for better readability */
-    font-weight: bold;
-    text-align: center;
-    text-shadow:  
-        0 0 10px rgba(255, 255, 0, 0.8), /* Soft yellow glow */
-        0 0 20px rgba(255, 255, 0, 0.6), /* Bright yellow glow */
-        0 0 30px rgba(255, 255, 0, 0.4); 
+  position: absolute;
+  top: 40%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 2;
+  font-family: 'Cinzel Decorative', serif;
+  color: #fffae6;
+  ;
+  font-size: 53px;
+  /* Adjust size for better readability */
+  font-weight: bold;
+  text-align: center;
+  text-shadow:
+    0 0 10px rgba(255, 255, 0, 0.8),
+    /* Soft yellow glow */
+    0 0 20px rgba(255, 255, 0, 0.6),
+    /* Bright yellow glow */
+    0 0 30px rgba(255, 255, 0, 0.4);
 }
 
 
@@ -206,10 +217,19 @@ button:hover {
 .spell-container {
   text-align: center;
   display: flex;
-  flex-direction: column;
   align-items: center;
-  justify-content: center;
+  justify-content: space-around;
   margin: 262px 0px;
+}
+
+.logo-img {
+  width: 33%;
+  border-radius: 10px;
+}
+
+.houses-img {
+  width: 33%;
+  border-radius: 10px;
 }
 
 .spell-internal-container {
@@ -300,6 +320,7 @@ button:hover {
 }
 
 @keyframes blinkCaret {
+
   from,
   to {
     border-color: transparent;
@@ -307,5 +328,14 @@ button:hover {
 
   50% {
     border-color: transparent;
+  }
+}
+
+
+@media (max-width: 768px) {
+
+  .logo-img,
+  .houses-img {
+    display: none;
   }
 }


### PR DESCRIPTION
### Add Images to Spell Container #21 

This pull request adds two images inside the `spell-container` div to enhance the visual appeal of the "Spell of the Day" feature. The following changes have been made:

#### HTML Changes:
- Added a **logo image** (`logo-img`) to the top of the spell container:
  - Source: [https://wallpapercave.com/wp/wp2275854.png](https://wallpapercave.com/wp/wp2275854.png)
  - Alt text: "logo"
- Added a **houses image** (`houses-img`) to the bottom of the spell container:
  - Source: [https://wallpapercave.com/wp/wp12750430.jpg](https://wallpapercave.com/wp/wp12750430.jpg)
  - Alt text: "houses"

#### CSS Changes:
- Added styling for `.logo-img` to ensure the image scales correctly and maintains visual balance within the container.
- Added styling for `.houses-img` to keep it properly aligned at the bottom of the spell container.

##### Ignore others changes they are caused by the VScode code formatter. 
 let me know if any improvements or adjustments are needed.