### PR TITLE
Add Spell Representation with Emojis (closes #77)

### DIFF
--- a/script.js
+++ b/script.js
@@ -73,7 +73,7 @@ const spells = [
   "Avada Kedavra 💀",       // The killing curse, symbolized by a skull.
   "Accio 🧲",               // A summoning spell, represented by a magnet for attraction.
   "Stupefy ⚡",              // The stunning spell, represented by a lightning bolt.
-  "Wingardium Leviosa 🪄",   // The levitation spell, represented by a wand.
+  "Wingardium Leviosa 🦋",   // The levitation spell, represented by a wand.
   "Alohomora 🗝️",           // Unlocking spell, represented by a key.
   "Lumos 🔦",               // The light-producing spell, represented by a flashlight.
 ];

--- a/script.js
+++ b/script.js
@@ -68,14 +68,14 @@ document.getElementById("quizForm").addEventListener("submit", function (e) {
 });
 
 const spells = [
-  "Expecto Patronum",
-  "Alarte Ascendare",
-  "Avada Kedavra",
-  "Accio",
-  "Stupefy",
-  "Wingardium Leviosa",
-  "Alohomora",
-  "Lumos",
+  "Expecto Patronum 🦌",    // A Patronus, often an animal like a stag.
+  "Alarte Ascendare 🦅",    // A spell that makes things ascend, represented by a flying bird.
+  "Avada Kedavra 💀",       // The killing curse, symbolized by a skull.
+  "Accio 🧲",               // A summoning spell, represented by a magnet for attraction.
+  "Stupefy ⚡",              // The stunning spell, represented by a lightning bolt.
+  "Wingardium Leviosa 🪄",   // The levitation spell, represented by a wand.
+  "Alohomora 🗝️",           // Unlocking spell, represented by a key.
+  "Lumos 🔦",               // The light-producing spell, represented by a flashlight.
 ];
 
 function getSpellOfTheDay() {


### PR DESCRIPTION
Previously, the `spells` constants in `script.js` was represented using plain text, resulting in a simplistic appearance when a spell is initialized for the user. By adding emojis to each spell, users can now gain a clearer understanding of what each spell represents, enhancing the overall user experience.


Could you please add the hacktoberfest-accepted label to this PR? Thank you! 🙏🏻